### PR TITLE
Bug fixes

### DIFF
--- a/hud.c
+++ b/hud.c
@@ -46,6 +46,8 @@ void draw_hud_row_1(
     int term_w, 
     int current_color_pair, 
     bool is_text_mode) {
+
+    (void)filename;
     
     if (canvas == NULL) {
         mPrint("canvas is null");

--- a/main.c
+++ b/main.c
@@ -265,7 +265,7 @@ void draw_initial_ascii() {
     int fg_color = get_fg_color(color_array, MAX_COLOR_PAIRS, current_color_pair);
     int bg_color = get_bg_color(color_array, MAX_COLOR_PAIRS, current_color_pair);
     for (int i=0; i < 3; i++) {
-        for (int j=0; j < strlen(lines[i]); j++) {
+        for (size_t j=0; j < strlen(lines[i]); j++) {
             write_char_to_canvas(i, j, lines[i][j], fg_color, bg_color);
         }
     }

--- a/tools.c
+++ b/tools.c
@@ -65,7 +65,7 @@ void read_ascii_into_canvas(FILE *fp, canvas_pixel_t **canvas, int canvas_height
     while (fgets(buffer, 1024, fp) != NULL) {
         h++;
         int w = 0;
-        for (int i = 0; i < strlen(buffer); i++) {
+        for (size_t i = 0; i < strlen(buffer); i++) {
             //char c = buffer[i];
             unsigned char c = buffer[i];
             if (c == 0x03) {
@@ -214,7 +214,7 @@ void get_ascii_width_height_from_file(FILE *fp, int *h, int *w) {
 
     while (fgets(buffer, 1024, fp) != NULL) {
         int width_for_this_line = 0;
-        for(int i=0; i<strlen(buffer); i++) {
+        for(size_t i=0; i<strlen(buffer); i++) {
             char c = buffer[i];   
 
             // color-codes are preceded by 0x03 and do not count towards width total


### PR DESCRIPTION
Fixed to compiler warnings produced by adding -Wextra to FLAGS.

In hud.c, there's an unused function parameter in draw_hud_row_1. We mute the warning by casting the unused parameter to void.

In main.c and tools.c, there are comparisons with integers of different signedness. They are trivially fixed by making the loop index unsigned.